### PR TITLE
feat: add changelog

### DIFF
--- a/.changelog-config.yml
+++ b/.changelog-config.yml
@@ -1,0 +1,29 @@
+changelog_type: 'commit_message' # or 'pull_request'
+header_prefix: 'Version:'
+commit_changelog: true
+comment_changelog: true
+include_unlabeled_changes: true
+unlabeled_group_title: 'Unlabeled Changes'
+pull_request_title_regex: '^Release'
+version_regex: 'v?([0-9]{1,2})+[.]+([0-9]{1,2})+[.]+([0-9]{1,2})\s\(\d{1,2}-\d{1,2}-\d{4}\)'
+exclude_labels:
+  - bot
+  - dependabot
+  - ci
+group_config:
+  - title: Bug Fixes
+    labels:
+      - bug
+      - bugfix
+  - title: Code Improvements
+    labels:
+      - improvements
+      - enhancement
+  - title: New Features
+    labels:
+      - feature
+  - title: Documentation Updates
+    labels:
+      - docs
+      - documentation
+      - doc

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,32 @@
+name: Changelog CI
+
+on:
+  pull_request:
+    types: [ opened ]
+
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Set Release Version'
+        required: true
+
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Changelog CI
+        uses: saadmk11/changelog-ci@v1.1.2
+        with:
+          changelog_filename: CHANGELOG.md
+          config_file: .changelog-config.yml
+          committer_username: 'github-actions[bot]'
+          committer_email: 'github-actions[bot]@users.noreply.github.com'
+          release_version: ${{ github.event.inputs.release_version }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Este PR implementa la funcionalidad de Changelog automático mediante GitHub Actions, permitiendo generar y actualizar el changelog del proyecto de forma automática cada vez que se abre un pull request.